### PR TITLE
New shorter URI for CRLs

### DIFF
--- a/isrg-root-x2.crl_url
+++ b/isrg-root-x2.crl_url
@@ -1,1 +1,1 @@
-http://c.lencr.org
+http://x2.c.lencr.org

--- a/isrgrootx1.crl_url
+++ b/isrgrootx1.crl_url
@@ -1,1 +1,1 @@
-http://crl.root-x1.letsencrypt.org
+http://x1.c.lencr.org


### PR DESCRIPTION
To make certificates as small as possible Let's Encrypt started to use lencr.org domain for CRLs distribution, details in the https://letsencrypt.org/docs/lencr.org/